### PR TITLE
Add query param for initial search

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -151,8 +151,24 @@ var app = new Vue({
   },
   watch: {
     filteredServers: activateAllClipboards
+  },
+  created() {
+    let search = getQueryParam('search');
+    if (search) {
+      this.search = search;
+    }
   }
 });
+
+function getQueryParam(name) {
+  var params = window.location.search.substring(1).split('&');
+  for (var i = 0; i < params.length; i++) {
+    var param = params[i].split('=', 2);
+    if (param[0] === name) {
+      return decodeURIComponent(param[1]);
+    }
+  }
+}
 
 function activateAllClipboards() {
   // TODO: Get the timing to work without setTimeout

--- a/js/main.js
+++ b/js/main.js
@@ -161,6 +161,8 @@ var app = new Vue({
 });
 
 function getQueryParam(name) {
+  // Could use URLSearchParams if IE is considered dead
+  // but dumb querystring parsing is also not too bad...
   var params = window.location.search.substring(1).split('&');
   for (var i = 0; i < params.length; i++) {
     var param = params[i].split('=', 2);


### PR DESCRIPTION
e.g. 61C can link to `https://hivemind.eecs.berkeley.edu/?search=hive` and enjoy less accidents.

Could use `URLSearchParams` if IE is considered dead here[^1], but dumb querystring parsing is also not too bad...

[^1]: https://caniuse.com/urlsearchparams